### PR TITLE
feat: integrate Symbol editor

### DIFF
--- a/web/components/symbolEditor/EngineeringSymbolEditor.tsx
+++ b/web/components/symbolEditor/EngineeringSymbolEditor.tsx
@@ -12,12 +12,10 @@ export type SymbolEditorProps = {
 };
 
 const defaultStyle: React.CSSProperties = {
-	position: 'absolute',
-	top: 0,
-	left: 0,
-	right: 0,
-	bottom: 0,
-	background: 'grey',
+	position: 'relative',
+	height: '100%',
+	width: '100%',
+	background: '#e7e5e4',
 };
 
 export const EngineeringSymbolEditor: FC<SymbolEditorProps> = ({ editorEventHandler, command, style }: SymbolEditorProps) => {

--- a/web/components/symbolEditor/EngineeringSymbolEditor.tsx
+++ b/web/components/symbolEditor/EngineeringSymbolEditor.tsx
@@ -20,7 +20,7 @@ const defaultStyle: React.CSSProperties = {
 	background: 'grey',
 };
 
-const EngineeringSymbolEditor: FC<SymbolEditorProps> = ({ editorEventHandler, command, style }: SymbolEditorProps) => {
+export const EngineeringSymbolEditor: FC<SymbolEditorProps> = ({ editorEventHandler, command, style }: SymbolEditorProps) => {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const editorRef = useRef<World | null>(null);
@@ -52,5 +52,3 @@ const EngineeringSymbolEditor: FC<SymbolEditorProps> = ({ editorEventHandler, co
 		</div>
 	);
 };
-
-export default EngineeringSymbolEditor;

--- a/web/components/symbolEditor/index.ts
+++ b/web/components/symbolEditor/index.ts
@@ -1,0 +1,4 @@
+export * from './EngineeringSymbolEditor';
+export * from './models/EditorCommand';
+export * from './models/EditorEvent';
+export * from './models/SymbolData';

--- a/web/pages/edit/index.page.tsx
+++ b/web/pages/edit/index.page.tsx
@@ -42,9 +42,7 @@ import {
 	SymbolUploadStore,
 } from '../../store';
 import React from 'react';
-import EngineeringSymbolEditor from '../../components/symbolEditor/EngineeringSymbolEditor';
-import { SymbolEditorEvent } from '../../components/symbolEditor/models/EditorEvent';
-import { EditorCommandMessage } from '../../components/symbolEditor/models/EditorCommand';
+import { EditorCommandMessage, EngineeringSymbolEditor, SymbolEditorEvent } from '../../components/symbolEditor';
 
 // const icons = allSymbols.map(({ key, geometry, ...rest }) => ({
 // 	key,

--- a/web/pages/edit/index.page.tsx
+++ b/web/pages/edit/index.page.tsx
@@ -409,13 +409,8 @@ const Edit: NextPage<EditPageProps> = ({ theme }) => {
 		console.log(`EDITOR-EVENT:${event.type}:${event.reason}`);
 		console.log('Event data: ', event.data);
 		console.log('Symbol state: ', event.symbolState);
-	};
 
-	const editorStyle: React.CSSProperties = {
-		position: 'relative',
-		height: '100%',
-		width: '100%',
-		background: '#e7e5e4',
+		// Add a switch statement on 'event.type'...
 	};
 
 	const [command, setCommand] = useState<EditorCommandMessage | undefined>();
@@ -441,7 +436,7 @@ const Edit: NextPage<EditPageProps> = ({ theme }) => {
 						{isSvgFileLoading && <WeatherLoader />}
 
 						<PanelPresentationContentStyled>
-							{!!selectedSymbol && <EngineeringSymbolEditor editorEventHandler={onEditorEvent} style={editorStyle} command={command} />}
+							{!!selectedSymbol && <EngineeringSymbolEditor editorEventHandler={onEditorEvent} command={command} />}
 						</PanelPresentationContentStyled>
 
 						{finishManageSymbolsQuery && selectedSymbol && (

--- a/web/pages/edit/index.page.tsx
+++ b/web/pages/edit/index.page.tsx
@@ -42,6 +42,9 @@ import {
 	SymbolUploadStore,
 } from '../../store';
 import React from 'react';
+import EngineeringSymbolEditor from '../../components/symbolEditor/EngineeringSymbolEditor';
+import { SymbolEditorEvent } from '../../components/symbolEditor/models/EditorEvent';
+import { EditorCommandMessage } from '../../components/symbolEditor/models/EditorCommand';
 
 // const icons = allSymbols.map(({ key, geometry, ...rest }) => ({
 // 	key,
@@ -186,6 +189,20 @@ const Edit: NextPage<EditPageProps> = ({ theme }) => {
 		// setEnableReinitialize(true);
 
 		const timer = setTimeout(() => setEnableReinitialize(false), 1000);
+
+		// Load symbol into editor
+		setCommand({
+			type: 'Symbol',
+			action: 'Load',
+			data: {
+				name: symbol.id,
+				path: symbol.geometry,
+				width: symbol.width,
+				height: symbol.height,
+				centerOfRotation: { x: symbol.width / 2, y: symbol.height / 2 }, // We don't have CoR in API yet,
+				connectors: symbol.connectors,
+			},
+		});
 
 		return () => {
 			clearTimeout(timer);
@@ -390,6 +407,20 @@ const Edit: NextPage<EditPageProps> = ({ theme }) => {
 		},
 	];
 
+	const onEditorEvent = (event: SymbolEditorEvent) => {
+		console.log(`EDITOR-EVENT:${event.type}:${event.reason}`);
+		console.log(event.data);
+	};
+
+	const editorStyle: React.CSSProperties = {
+		position: 'relative',
+		height: '100%',
+		width: '100%',
+		background: '#e7e5e4',
+	};
+
+	const [command, setCommand] = useState<EditorCommandMessage | undefined>();
+
 	return (
 		<AuthenticatedTemplate>
 			<Head>
@@ -411,18 +442,7 @@ const Edit: NextPage<EditPageProps> = ({ theme }) => {
 						{isSvgFileLoading && <WeatherLoader />}
 
 						<PanelPresentationContentStyled>
-							{!!selectedSymbol && (
-								<SvgComponent
-									renderConnectors
-									viewBoxHeight={selectedSymbol.height}
-									viewBoxWidth={selectedSymbol.width}
-									connectors={selectedSymbol.connectors}
-									height={250}
-									width={250}
-									fill={theme.fill}
-									path={selectedSymbol.geometry}
-								/>
-							)}
+							{!!selectedSymbol && <EngineeringSymbolEditor editorEventHandler={onEditorEvent} style={editorStyle} command={command} />}
 						</PanelPresentationContentStyled>
 
 						{finishManageSymbolsQuery && selectedSymbol && (

--- a/web/pages/edit/index.page.tsx
+++ b/web/pages/edit/index.page.tsx
@@ -409,7 +409,8 @@ const Edit: NextPage<EditPageProps> = ({ theme }) => {
 
 	const onEditorEvent = (event: SymbolEditorEvent) => {
 		console.log(`EDITOR-EVENT:${event.type}:${event.reason}`);
-		console.log(event.data);
+		console.log('Event data: ', event.data);
+		console.log('Symbol state: ', event.symbolState);
 	};
 
 	const editorStyle: React.CSSProperties = {

--- a/web/pages/edit/styles.ts
+++ b/web/pages/edit/styles.ts
@@ -13,21 +13,37 @@ export const PanelPresentationStyled = styled.div`
 `;
 
 export const PanelPresentationContentStyled = styled.div`
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
+	position: relative;
+	top: 0;
+	left: 0;
+	width: 1000px;
+	height: ${HEIGHT}px;
 
-	svg {
-		width: 250px;
-		height: auto;
-		fill: ${({ theme }) => theme.fill};
-	}
+	background: green;
 
-	#Annotations > * {
-		fill: ${({ theme }) => theme.textRed};
+	canvas {
+		display: block;
+		width: 100%;
+		height: 100%;
 	}
 `;
+
+// export const PanelPresentationContentStyled = styled.div`
+// 	position: absolute;
+// 	top: 50%;
+// 	left: 50%;
+// 	transform: translate(-50%, -50%);
+
+// 	svg {
+// 		width: 250px;
+// 		height: auto;
+// 		fill: ${({ theme }) => theme.fill};
+// 	}
+
+// 	#Annotations > * {
+// 		fill: ${({ theme }) => theme.textRed};
+// 	}
+// `;
 
 export const PanelSymbolsStyled = styled.div`
 	padding: 80px 0 0;

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -1,1 +1,2 @@
 @import 'https://cdn.eds.equinor.com/font/equinor-font.css';
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;1,300&display=swap');


### PR DESCRIPTION
This PR is an example of basic integration/use of the symbol editor.

NOTE: Only "edit" symbol will load the symbol into the editor, other actions (new and update) is not implemented.

See this example of how to integrate further: https://github.com/equinor/dugtrio-experimental/blob/main/users/loba/symbol-editor/src/App.tsx